### PR TITLE
chore: add sharding config to clickhouse

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -71,22 +71,22 @@ jobs:
       - name: Validate Module Structure
         id: validate
         run: |
-          # Check for required files
+          # Check for required files in module root
           for file in README.md variables.tf outputs.tf versions.tf; do
             if [ ! -f "$file" ]; then
               echo "::error::Missing required file: $file"
               exit 1
             fi
           done
-          
-          # Validate all .tf files syntax
-          for file in $(find . -name "*.tf"); do
+
+          # Validate all .tf files syntax, excluding examples directory
+          for file in $(find . -name "*.tf" -not -path "./examples/*"); do
             if ! terraform fmt -check "$file"; then
               echo "::error::Invalid HCL syntax in $file"
               exit 1
             fi
           done
-          
+
           # Check for template files if config directory exists
           if [ -d "config" ]; then
             for tpl in config/*/**.tpl; do
@@ -146,9 +146,9 @@ jobs:
             const output = `### Module: \`${{ matrix.module }}\`
             ### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             ### Module Structure Validation 🤖\`${{ steps.validate.outcome }}\`
-            
+
             *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
-            
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,8 +32,8 @@ jobs:
 
       - id: set-modules
         run: |
-          # Find all directories containing .tf files, excluding .terraform directories
-          MODULES=$(find . -type f -name "*.tf" -not -path "*/\.*" -exec dirname {} \; | sort -u | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')
+          # Find all directories containing .tf files, excluding .terraform and examples directories
+          MODULES=$(find . -type f -name "*.tf" -not -path "*/\.*" -not -path "*/examples/*" -exec dirname {} \; | sort -u | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')
           echo "modules=$MODULES" >> $GITHUB_OUTPUT
 
   validate:

--- a/.kics.config
+++ b/.kics.config
@@ -1,7 +1,7 @@
 {
   "exclude-queries": [
     "c5b31ab9-0f26-4a49-b8aa-4cc064392f4d",  # S3 Bucket Without Enabled MFA Delete
-    "4728cd65-a20c-49da-8b31-9c08b423e4db"   # Unrestricted Security Group Ingress
+    "4728cd65-a20c-49da-8b31-9c08b423e4db",   # Unrestricted Security Group Ingress
     "487f4be7-3fd9-4506-a07a-eae252180c08"   # Generic password
   ],
   "exclude-severities": [],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,5 @@ repos:
       - id: terraform_validate
         args:
           - --hook-config=--retry-once-with-cleanup=true
+        files: ^clickhouse/.*\.tf$
+        exclude: ^clickhouse/examples/.*\.tf$

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -147,6 +147,7 @@ At this stage the data should be present on all nodes of the cluster given that 
 | <a name="input_keeper_volume_size"></a> [keeper\_volume\_size](#input\_keeper\_volume\_size) | The size of the EBS volume for the ClickHouse keepers | `number` | `10` | no |
 | <a name="input_keeper_volume_type"></a> [keeper\_volume\_type](#input\_keeper\_volume\_type) | The type of EBS volume for the ClickHouse keepers | `string` | `"gp2"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy to | `string` | `"us-west-2"` | no |
+| <a name="input_shards"></a> [shards](#input\_shards) | List of shards and their configuration. Each shard specifies how many replicas it should have and optionally its weight. | <pre>list(object({<br/>    replica_count = number<br/>    weight        = optional(number, 1)<br/>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/clickhouse/config/server/macros.xml.tpl
+++ b/clickhouse/config/server/macros.xml.tpl
@@ -1,7 +1,7 @@
 <clickhouse>
     <macros>
-        <shard>${shard_id}</shard>
-        <replica>${replica_id}</replica>
+        <shard>${shard_index}</shard>
+        <replica>${replica_index}</replica>
         <cluster>${cluster_name}</cluster>
     </macros>
 </clickhouse>

--- a/clickhouse/config/server/remote-servers.xml.tpl
+++ b/clickhouse/config/server/remote-servers.xml.tpl
@@ -2,15 +2,18 @@
     <remote_servers replace="true">
         <${cluster_name}>
             <secret>${cluster_secret}</secret>
+            %{~ for shard_index, shard in shard_hosts ~}
             <shard>
                 <internal_replication>true</internal_replication>
-                %{~for replica in replica_hosts~}
+                <weight>${shard.weight}</weight>
+                %{~ for replica in shard.replicas ~}
                 <replica>
-                    <host>${replica}</host>
+                    <host>${replica.host}</host>
                     <port>9000</port>
                 </replica>
                 %{~ endfor ~}
             </shard>
+            %{~ endfor ~}
         </${cluster_name}>
     </remote_servers>
 </clickhouse>

--- a/clickhouse/examples/multi-shard/main.tf
+++ b/clickhouse/examples/multi-shard/main.tf
@@ -1,0 +1,40 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "clickhouse_sharded" {
+  source = "../../clickhouse"
+
+  # 3 shards with 2 replicas each for scalability and HA
+  shards = [
+    {
+      replica_count = 2
+      weight        = 2 # Higher weight for newer, more powerful nodes
+    },
+    {
+      replica_count = 2
+      weight        = 1
+    },
+    {
+      replica_count = 2
+      weight        = 1
+    }
+  ]
+
+  # 3 keeper nodes for HA quorum
+  keeper_node_count = 3
+
+  # Use powerful instances for sharded setup
+  clickhouse_instance_type = "r5.2xlarge"
+  clickhouse_volume_size   = 200
+
+  # Only allow connections from your network
+  allowed_cidr_blocks = ["10.0.0.0/8"]
+
+  cluster_name = "clickhouse-sharded"
+
+  tags = {
+    Environment = "production"
+    Project     = "analytics"
+  }
+}

--- a/clickhouse/examples/single-shard/main.tf
+++ b/clickhouse/examples/single-shard/main.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "clickhouse_ha" {
+  source = "../../clickhouse"
+
+  # Single shard with 3 replicas for high availability
+  shards = [
+    {
+      replica_count = 3
+      weight        = 1
+    }
+  ]
+
+  # 3 keeper nodes for HA quorum
+  keeper_node_count = 3
+
+  # Use more powerful instances for production
+  clickhouse_instance_type = "r5.xlarge"
+  clickhouse_volume_size   = 100
+
+  # Only allow connections from your network
+  allowed_cidr_blocks = ["10.0.0.0/8"]
+
+  cluster_name = "clickhouse-ha"
+
+  tags = {
+    Environment = "production"
+    Project     = "analytics"
+  }
+}

--- a/clickhouse/locals.tf
+++ b/clickhouse/locals.tf
@@ -8,15 +8,37 @@ locals {
 
   internal_domain = "clickhouse.internal"
 
-  cluster_nodes = {
-    for i in range(var.cluster_node_count) : "clickhouse_cluster_${i + 1}" => {
-      id           = i + 1
-      name         = "clickhouse_cluster_${i + 1}"
-      host         = "clickhouse_cluster_${i + 1}.${local.internal_domain}"
-      subnet_index = i % length(local.private_subnets)
+  # Calculate total nodes needed
+  total_replicas = sum([for shard in var.shards : shard.replica_count])
+
+  # Create a map of all cluster nodes with their shard and replica information
+  cluster_nodes = merge([
+    for shard_index, shard in var.shards : {
+      for replica_index in range(shard.replica_count) :
+      "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}" => {
+        id            = "${shard_index + 1}-${replica_index + 1}"
+        name          = "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}"
+        host          = "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}.${local.internal_domain}"
+        shard_index   = shard_index + 1
+        replica_index = replica_index + 1
+        subnet_index  = (shard_index * shard.replica_count + replica_index) % length(local.private_subnets)
+      }
+    }
+  ]...)
+
+  # Create shard configuration for the remote-servers.xml template
+  shard_hosts = {
+    for shard_index, shard in var.shards : shard_index + 1 => {
+      weight = shard.weight
+      replicas = [
+        for replica_index in range(shard.replica_count) : {
+          host = "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}.${local.internal_domain}"
+        }
+      ]
     }
   }
 
+  # Keeper nodes configuration (remains unchanged)
   keeper_nodes = {
     for i in range(var.keeper_node_count) : "clickhouse_keeper_${i + 1}" => {
       id           = i + 1

--- a/clickhouse/s3.tf
+++ b/clickhouse/s3.tf
@@ -41,10 +41,9 @@ resource "aws_s3_object" "cluster_remote_server_configuration" {
   bucket   = aws_s3_bucket.configuration.bucket
   key      = "${each.value.name}/config.d/remote-servers.xml"
   content = templatefile("${path.module}/config/server/remote-servers.xml.tpl", {
-    server_id      = each.value.id,
     cluster_name   = var.cluster_name
     cluster_secret = random_password.cluster_secret.result
-    replica_hosts  = [for _, record in aws_route53_record.clickhouse_cluster : record.fqdn]
+    shard_hosts    = local.shard_hosts
   })
 }
 
@@ -62,11 +61,12 @@ resource "aws_s3_object" "cluster_macros" {
   bucket   = aws_s3_bucket.configuration.bucket
   key      = "${each.value.name}/config.d/macros.xml"
   content = templatefile("${path.module}/config/server/macros.xml.tpl", {
-    cluster_name = var.cluster_name
-    shard_id     = 1
-    replica_id   = each.value.id
+    cluster_name  = var.cluster_name
+    shard_index   = each.value.shard_index
+    replica_index = each.value.replica_index
   })
 }
+
 
 resource "aws_s3_object" "cluster_cloudwatch_configuration" {
   for_each = local.cluster_nodes

--- a/clickhouse/variables.tf
+++ b/clickhouse/variables.tf
@@ -95,3 +95,21 @@ variable "admin_user_networks" {
   description = "List of networks allowed to connect as admin user"
   default     = ["::/0"] # Allow from anywhere by default
 }
+
+variable "shards" {
+  type = list(object({
+    replica_count = number
+    weight        = optional(number, 1)
+  }))
+  description = "List of shards and their configuration. Each shard specifies how many replicas it should have and optionally its weight."
+
+  validation {
+    condition     = length(var.shards) > 0
+    error_message = "At least one shard must be configured"
+  }
+
+  validation {
+    condition     = alltrue([for shard in var.shards : shard.replica_count > 0])
+    error_message = "Each shard must have at least one replica"
+  }
+}


### PR DESCRIPTION
Add Sharding Support to ClickHouse Module

- Replace single-shard configuration with multi-shard support
- Update variables to allow configurable shard and replica counts per shard
- Modify locals.tf to generate proper node configurations for shards and replicas
- Update remote-servers.xml template to support sharded configuration
- Support configurable shard weights for data distribution

Example usage:
```hcl
module "clickhouse" {
 source = "./clickhouse"
 
 shards = [
   {
     replica_count = 2  # First shard with 2 replicas
     weight       = 1
   },
   {
     replica_count = 2  # Second shard with 2 replicas
     weight       = 1
   }
 ]
}
```
Examples directory added with single and multi shard.