### PR TITLE
chore: add global s3 config to clickhouse

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -100,6 +100,7 @@ At this stage the data should be present on all nodes of the cluster given that 
 | [aws_s3_object.cluster_macros](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |
 | [aws_s3_object.cluster_network_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |
 | [aws_s3_object.cluster_remote_server_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |
+| [aws_s3_object.cluster_s3_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |
 | [aws_s3_object.cluster_use_keeper_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |
 | [aws_s3_object.cluster_users_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |
 | [aws_s3_object.keeper_cloudwatch_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.82.2/docs/resources/s3_object) | resource |

--- a/clickhouse/config/server/s3.xml.tpl
+++ b/clickhouse/config/server/s3.xml.tpl
@@ -1,0 +1,5 @@
+<clickhouse>
+    <s3>
+    <use_environment_credentials>true</use_environment_credentials>
+    </s3>
+</clickhouse>

--- a/clickhouse/iam.tf
+++ b/clickhouse/iam.tf
@@ -34,11 +34,21 @@ resource "aws_iam_policy" "s3_policy" {
   description = "Allow access to S3 bucket"
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["s3:*"]
-      Resource = [aws_s3_bucket.configuration.arn, "${aws_s3_bucket.configuration.arn}/*"]
-    }]
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          aws_s3_bucket.configuration.arn,
+          "${aws_s3_bucket.configuration.arn}/*"
+        ]
+      }
+    ]
   })
 }
 
@@ -54,6 +64,3 @@ resource "aws_iam_role_policy_attachment" "cw_policy_attachment" {
   role       = aws_iam_role.clickhouse_role.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
-
-
-

--- a/clickhouse/s3.tf
+++ b/clickhouse/s3.tf
@@ -113,3 +113,10 @@ resource "aws_s3_object" "cluster_users_configuration" {
     admin_allowed_ips     = var.admin_user_networks
   })
 }
+
+resource "aws_s3_object" "cluster_s3_configuration" {
+  for_each = local.cluster_nodes
+  bucket   = aws_s3_bucket.configuration.bucket
+  key      = "${each.value.name}/config.d/s3.xml"
+  content  = file("${path.module}/config/server/s3.xml.tpl")
+}


### PR DESCRIPTION
ref: https://cloudqueryio.slack.com/archives/C05MFM9L7F0/p1738350166373479

# Add S3 Configuration for ClickHouse

## Description
This PR adds S3 configuration for ClickHouse to enable environment credential usage. This allows ClickHouse to securely access S3 using IAM instance profiles without requiring explicit credentials in configuration files.

## Changes
- Added new `s3.xml.tpl` configuration template
- Created new S3 bucket object resource to deploy configuration
- Updated IAM policy to explicitly define required S3 permissions restricting to minimum required actions

CC: @erezrokah 