### PR TITLE
feat: Add `name_prefix` variable

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -147,6 +147,7 @@ At this stage the data should be present on all nodes of the cluster given that 
 | <a name="input_keeper_node_count"></a> [keeper\_node\_count](#input\_keeper\_node\_count) | The number of ClickHouse keepers to deploy | `number` | `3` | no |
 | <a name="input_keeper_volume_size"></a> [keeper\_volume\_size](#input\_keeper\_volume\_size) | The size of the EBS volume for the ClickHouse keepers | `number` | `10` | no |
 | <a name="input_keeper_volume_type"></a> [keeper\_volume\_type](#input\_keeper\_volume\_type) | The type of EBS volume for the ClickHouse keepers | `string` | `"gp2"` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for various resources that will be created, used to avoid conflicts with other resources | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy to | `string` | `"us-west-2"` | no |
 | <a name="input_shards"></a> [shards](#input\_shards) | List of shards and their configuration. Each shard specifies how many replicas it should have and optionally its weight. | <pre>list(object({<br/>    replica_count = number<br/>    weight        = optional(number, 1)<br/>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the ClickHouse cluster | `map(string)` | <pre>{<br/>  "Project": "ClickHouse Cluster"<br/>}</pre> | no |

--- a/clickhouse/cloudwatch.tf
+++ b/clickhouse/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_group" "clickhouse" {
-  name_prefix = "clickhouse-"
+  name_prefix = "${var.name_prefix}clickhouse-"
 }
 
 resource "aws_cloudwatch_log_group" "keeper" {
-  name_prefix = "keeper-"
+  name_prefix = "${var.name_prefix}keeper-"
 }

--- a/clickhouse/examples/multi-shard/main.tf
+++ b/clickhouse/examples/multi-shard/main.tf
@@ -31,7 +31,9 @@ module "clickhouse_sharded" {
   # Only allow connections from your network
   allowed_cidr_blocks = ["10.0.0.0/8"]
 
-  cluster_name = "clickhouse-sharded"
+  cluster_name = "clickhouse-multi-shard"
+
+  name_prefix = "example-"
 
   tags = {
     Environment = "production"

--- a/clickhouse/examples/single-shard/main.tf
+++ b/clickhouse/examples/single-shard/main.tf
@@ -23,7 +23,9 @@ module "clickhouse_ha" {
   # Only allow connections from your network
   allowed_cidr_blocks = ["10.0.0.0/8"]
 
-  cluster_name = "clickhouse-ha"
+  cluster_name = "clickhouse-single-shard"
+
+  name_prefix = "example-"
 
   tags = {
     Environment = "production"

--- a/clickhouse/iam.tf
+++ b/clickhouse/iam.tf
@@ -1,6 +1,6 @@
 # IAM role and instance profile for SSM
 resource "aws_iam_role" "clickhouse_role" {
-  name = "clickhouse-role"
+  name = "${var.name_prefix}clickhouse-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -19,18 +19,18 @@ resource "aws_iam_role_policy_attachment" "ssm_policy" {
 }
 
 resource "aws_iam_instance_profile" "clickhouse_cluster_profile" {
-  name = "clickhouse-cluster-profile"
+  name = "${var.name_prefix}clickhouse-cluster-profile"
   role = aws_iam_role.clickhouse_role.name
 }
 
 resource "aws_iam_instance_profile" "clickhouse_keeper_profile" {
-  name = "clickhouse-keeper-profile"
+  name = "${var.name_prefix}clickhouse-keeper-profile"
   role = aws_iam_role.clickhouse_role.name
 }
 
 // Allow profile access to s3 bucket
 resource "aws_iam_policy" "s3_policy" {
-  name        = "s3-policy"
+  name        = "${var.name_prefix}s3-policy"
   description = "Allow access to S3 bucket"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -54,7 +54,7 @@ resource "aws_iam_policy" "s3_policy" {
 
 // Attach the policy to the instance profile
 resource "aws_iam_policy_attachment" "s3_policy_attachment" {
-  name       = "s3-policy-attachment"
+  name       = "${var.name_prefix}clickhouse-s3-policy-attachment"
   policy_arn = aws_iam_policy.s3_policy.arn
   roles      = [aws_iam_instance_profile.clickhouse_cluster_profile.role, aws_iam_instance_profile.clickhouse_keeper_profile.role]
 }

--- a/clickhouse/locals.tf
+++ b/clickhouse/locals.tf
@@ -1,12 +1,12 @@
 locals {
-  name = "clickhouse-vpc"
+  name = "${var.name_prefix}clickhouse-vpc"
 
   vpc_cidr        = "10.0.0.0/16"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)
   public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + length(local.public_subnets))]
 
-  internal_domain = "clickhouse.internal"
+  internal_domain = "${var.name_prefix}clickhouse.internal"
 
   # Calculate total nodes needed
   total_replicas = sum([for shard in var.shards : shard.replica_count])
@@ -15,10 +15,10 @@ locals {
   cluster_nodes = merge([
     for shard_index, shard in var.shards : {
       for replica_index in range(shard.replica_count) :
-      "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}" => {
+      "${var.name_prefix}clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}" => {
         id            = "${shard_index + 1}-${replica_index + 1}"
-        name          = "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}"
-        host          = "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}.${local.internal_domain}"
+        name          = "${var.name_prefix}clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}"
+        host          = "${var.name_prefix}clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}.${local.internal_domain}"
         shard_index   = shard_index + 1
         replica_index = replica_index + 1
         subnet_index  = (shard_index * shard.replica_count + replica_index) % length(local.private_subnets)
@@ -32,7 +32,7 @@ locals {
       weight = shard.weight
       replicas = [
         for replica_index in range(shard.replica_count) : {
-          host = "clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}.${local.internal_domain}"
+          host = "${var.name_prefix}clickhouse_cluster_s${shard_index + 1}r${replica_index + 1}.${local.internal_domain}"
         }
       ]
     }
@@ -40,10 +40,10 @@ locals {
 
   # Keeper nodes configuration (remains unchanged)
   keeper_nodes = {
-    for i in range(var.keeper_node_count) : "clickhouse_keeper_${i + 1}" => {
+    for i in range(var.keeper_node_count) : "${var.name_prefix}clickhouse_keeper_${i + 1}" => {
       id           = i + 1
-      name         = "clickhouse_keeper_${i + 1}"
-      host         = "clickhouse_keeper_${i + 1}.${local.internal_domain}"
+      name         = "${var.name_prefix}clickhouse_keeper_${i + 1}"
+      host         = "${var.name_prefix}clickhouse_keeper_${i + 1}.${local.internal_domain}"
       subnet_index = i % length(local.private_subnets)
     }
   }

--- a/clickhouse/nlb.tf
+++ b/clickhouse/nlb.tf
@@ -1,6 +1,6 @@
 resource "aws_lb" "nlb" {
   count              = var.enable_nlb ? 1 : 0
-  name               = "clickhouse-nlb"
+  name               = "${var.name_prefix}clickhouse-nlb"
   internal           = false
   load_balancer_type = "network"
   security_groups    = [aws_security_group.nlb[0].id]
@@ -23,7 +23,7 @@ resource "aws_lb_listener" "clickhouse_nlb_listener" {
 
 resource "aws_lb_target_group" "clickhouse_nlb_target_group" {
   count       = var.enable_nlb ? 1 : 0
-  name        = "clickhouse-nlb-tg"
+  name        = "${var.name_prefix}clickhouse-nlb-tg"
   port        = 9000
   protocol    = "TCP"
   target_type = "instance"

--- a/clickhouse/s3.tf
+++ b/clickhouse/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "configuration" {
-  bucket_prefix = "clickhouse"
+  bucket_prefix = "${var.name_prefix}clickhouse"
   force_destroy = true
 }
 

--- a/clickhouse/sg.tf
+++ b/clickhouse/sg.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "nlb" {
   count       = var.enable_nlb ? 1 : 0
-  name        = "clickhouse-nlb-sg"
+  name        = "${var.name_prefix}clickhouse-nlb-sg"
   description = "Security group for the ClickHouse NLB"
   vpc_id      = module.vpc.vpc_id
 }
@@ -29,7 +29,7 @@ resource "aws_security_group_rule" "nlb_clickhouse_egress" {
 }
 
 resource "aws_security_group" "clickhouse_cluster" {
-  name        = "clickhouse_cluster-sg"
+  name        = "${var.name_prefix}clickhouse_cluster-sg"
   description = "Security group for the ClickHouse cluster"
   vpc_id      = module.vpc.vpc_id
 }
@@ -87,7 +87,7 @@ resource "aws_security_group_rule" "clickhouse_egress" {
 }
 
 resource "aws_security_group" "clickhouse_keeper" {
-  name        = "clickhouse-keeper-sg"
+  name        = "${var.name_prefix}clickhouse-keeper-sg"
   description = "Security group for the ClickHouse keepers"
   vpc_id      = module.vpc.vpc_id
 }

--- a/clickhouse/users.tf
+++ b/clickhouse/users.tf
@@ -10,7 +10,7 @@ resource "random_password" "admin_user" {
 
 # Store passwords in Secrets Manager for retrieval
 resource "aws_secretsmanager_secret" "clickhouse_credentials" {
-  name_prefix = "clickhouse-credentials-"
+  name_prefix = "${var.name_prefix}clickhouse-credentials-"
   description = "ClickHouse user credentials"
 }
 

--- a/clickhouse/variables.tf
+++ b/clickhouse/variables.tf
@@ -121,3 +121,13 @@ variable "tags" {
     Project = "ClickHouse Cluster"
   }
 }
+
+variable "name_prefix" {
+  type        = string
+  description = "Name prefix for various resources that will be created, used to avoid conflicts with other resources"
+  default     = ""
+  validation {
+    error_message = "name_prefix must be less than 10 characters and only contain alphanumeric characters and hyphens, and not start with a hyphen"
+    condition     = length(var.name_prefix) <= 10 && !startswith(var.name_prefix, "-") && can(regex("^[a-zA-Z0-9-]+$", var.name_prefix))
+  }
+}


### PR DESCRIPTION
This allows prefixing the names of the created resources so they are easier to identify under the same stack, and create multiple variants of the stack.

Happy to also close this if you think this is not needed.

We could also use `cluster_name` everywhere