### PR TITLE
fix: Examples names

### DIFF
--- a/clickhouse/examples/multi-shard/main.tf
+++ b/clickhouse/examples/multi-shard/main.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-west-2"
 }
 
-module "clickhouse_sharded" {
+module "clickhouse_multi_shard" {
   source = "../../"
 
   # 3 shards with 2 replicas each for scalability and HA

--- a/clickhouse/examples/single-shard/main.tf
+++ b/clickhouse/examples/single-shard/main.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-west-2"
 }
 
-module "clickhouse_ha" {
+module "clickhouse_single_shard" {
   source = "../.."
 
   # Single shard with 3 replicas for high availability


### PR DESCRIPTION
Not sure what's `ha` stands for. Aligned the names to match the examples directory names