### PR TITLE
chore: Use changed files action instead of path filters

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,18 +3,8 @@ name: "Terraform Module Validation"
 on:
   push:
     branches: ["main"]
-    paths:
-      - "**/README.md"
-      - "**/**.tf"
-      - "**/**.tpl"
-      - ".github/workflows/**"
   pull_request:
     branches: ["main"]
-    paths:
-      - "**/README.md"
-      - "**/**.tf"
-      - "**/**.tpl"
-      - ".github/workflows/**"
 
 permissions:
   contents: write
@@ -26,9 +16,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      files-changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            README.md
+            **/*.tf
+            **/*.tpl
+            .github/workflows/**
   discover:
     name: "Discover Modules and Examples"
     runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.files-changed == 'true'
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
       examples: ${{ steps.set-examples.outputs.examples }}


### PR DESCRIPTION
Path filters don't let us enforce checks via branch protection rules. Using the action and conditionally skipping the jobs will