### PR TITLE
core: Remove filters

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,26 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      files-changed: ${{ steps.changed-files.outputs.any_changed }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check if files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-        with:
-          files: |
-            README.md
-            **/*.tf
-            **/*.tpl
-            .github/workflows/**
   discover:
     name: "Discover Modules and Examples"
     runs-on: ubuntu-latest
-    needs: prepare
-    if: needs.prepare.outputs.files-changed == 'true'
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
       examples: ${{ steps.set-examples.outputs.examples }}


### PR DESCRIPTION
Ok the approach in https://github.com/cloudquery/terraform-cloudquery-modules/pull/21 doesn't work since we use matrix jobs so the job is not evaluated with the correct name when it's skipped.

![image](https://github.com/user-attachments/assets/220a2c16-50a9-4956-a64b-a931c38625ba)

Going to remove the filters, the workflows are fast enough so we can run all of them all the time for now 