### PR TITLE
fix: Use `cluster_name` on kms alias

### DIFF
--- a/clickhouse/cloudwatch.tf
+++ b/clickhouse/cloudwatch.tf
@@ -81,6 +81,6 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_kms_alias" "cloudwatch" {
-  name          = "alias/clickhouse-cloudwatch"
+  name          = "alias/${var.cluster_name}-cloudwatch"
   target_key_id = aws_kms_key.cloudwatch.key_id
 }


### PR DESCRIPTION
I had am existing resource conflict when trying to deploy the stack on our playground account