### PR TITLE
fix: Configure NLB internal/external correctly

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   security-events: write
-  # id-token: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -170,11 +170,11 @@ jobs:
         working-directory: ${{ matrix.example }}
 
     steps:
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: "arn:aws:iam::615713231484:role/terraform-cloudquery-modules-repo-role"
-      #     aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::615713231484:role/cq-playground-aws-github-action"
+          aws-region: us-east-1
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -191,5 +191,5 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
-      # - name: Terraform Plan
-      #   run: terraform plan
+      - name: Terraform Plan
+        run: terraform plan

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -71,6 +71,23 @@ jobs:
         id: fmt
         run: terraform fmt -check -recursive
 
+      - uses: terraform-linters/setup-tflint@v4
+        name: Setup TFLint
+        with:
+          tflint_version: v0.52.0
+
+      - name: Show version
+        run: tflint --version
+
+      - name: Init TFLint
+        run: tflint --init
+        env:
+          # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+          GITHUB_TOKEN: ${{ github.GH_CQ_BOT }}
+
+      - name: Run TFLint
+        run: tflint -f compact
+
       - name: Validate Module Structure
         id: validate
         run: |

--- a/clickhouse/cloudwatch.tf
+++ b/clickhouse/cloudwatch.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_group" "clickhouse" {
   name_prefix       = "clickhouse-"
-  retention_in_days = 30
+  retention_in_days = var.retention_period
 
   tags = var.tags
 

--- a/clickhouse/locals.tf
+++ b/clickhouse/locals.tf
@@ -8,23 +8,6 @@ locals {
 
   internal_domain = "${var.cluster_name}.internal"
 
-  validate_nlb_tls = (
-    !var.enable_nlb_tls ||                                                              # NLB TLS is disabled, no validation needed
-    (var.enable_nlb_tls && var.tls_certificate_arn != "" && !var.use_generated_cert) || # Using provided cert
-    (var.enable_nlb_tls && var.use_generated_cert && var.enable_encryption)             # Using generated cert with cluster encryption
-  )
-  validate_nlb_tls_check = regex("^$", (!local.validate_nlb_tls ? "Invalid NLB TLS configuration" : ""))
-
-  # Calculate total nodes needed
-  total_replicas = sum([for shard in var.shards : shard.replica_count])
-
-  validate_external_certs = (
-    !var.use_external_certs ||                                                                                              # Not using external certs, no validation needed
-    (var.use_external_certs && var.enable_encryption && var.external_ca_cert != "" && var.external_cert_secret_ids != null) # Using external certs with all required inputs
-  )
-  validate_external_certs_check = regex("^$", (!local.validate_external_certs ? "Invalid external certificate configuration" : ""))
-
-
   # Create a map of all cluster nodes with their shard and replica information
   cluster_nodes = merge([
     for shard_index, shard in var.shards : {

--- a/clickhouse/nlb.tf
+++ b/clickhouse/nlb.tf
@@ -1,7 +1,7 @@
 resource "aws_lb" "nlb" {
   count              = var.enable_nlb ? 1 : 0
   name               = "${var.cluster_name}-nlb"
-  internal           = false
+  internal           = var.nlb_type == "internal"
   load_balancer_type = "network"
   security_groups    = [aws_security_group.nlb[0].id]
   subnets            = var.nlb_type == "internal" ? module.vpc.private_subnets : module.vpc.public_subnets

--- a/clickhouse/sg.tf
+++ b/clickhouse/sg.tf
@@ -29,7 +29,7 @@ resource "aws_security_group_rule" "nlb_inbound" {
   from_port         = var.enable_encryption ? var.tcp_port_secure : var.tcp_port
   to_port           = var.enable_encryption ? var.tcp_port_secure : var.tcp_port
   protocol          = "tcp"
-  cidr_blocks       = var.nlb_type == "external" ? ["0.0.0.0/0"] : [local.vpc_cidr]
+  cidr_blocks       = var.nlb_type == "external" ? var.allowed_cidr_blocks : [local.vpc_cidr]
   description       = "Allow inbound traffic to NLB"
 }
 


### PR DESCRIPTION
The NLB was always being set to external [here](https://github.com/cloudquery/terraform-cloudquery-modules/pull/31/files#diff-891c42899b41fd711fdebaf992a9a0ff460715cfb881a3eedfcb513df2fec43cR4) instead of being defined by the `nlb_type` variable.

In addition:

- Configured the example to run a `terraform plan` against the `cq-playground` account
  - I also tried `localstack` but it isn't feature complete enough (at least the free version) to cover all of our resources. In this case I saw errors related to the ELB target group creation.
- Added `tflint` to the GHA PR checks to identify unused variables 