### PR TITLE
fix: Allow `ping` endpoint to be reached

### DIFF
--- a/clickhouse/nlb.tf
+++ b/clickhouse/nlb.tf
@@ -71,7 +71,7 @@ resource "aws_lb_target_group" "clickhouse_http_nlb_target_group" {
   count       = var.enable_nlb ? 1 : 0
   name        = "${substr(var.cluster_name, 0, 20)}-ch-http-tg"
   port        = var.enable_encryption ? var.https_port : var.http_port
-  protocol    = "TCP"
+  protocol    = var.enable_encryption ? "TLS" : "TCP"
   vpc_id      = module.vpc.vpc_id
   target_type = "instance"
 


### PR DESCRIPTION
Since the backend is using self-signed certificates, we also need ot use `TLS` (as we do for the 9440 target group)

```
❯ curl  "https://clickhouse.mnorbury.me:8443/ping"
Ok.
```